### PR TITLE
カート一覧編集削除機能の追加

### DIFF
--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -3,11 +3,21 @@ class CartItemsController < ApplicationController
     @cart_items = current_user.cart_items
   end
 
+  def create
+    # FIX: 問答無用で商品の一番をカートに追加している
+    # 本当は 商品詳細画面からitem_id を受け取る。
+    current_user.cart_items.create(item_id: 1)
+    redirect_to cart_items_path
+  end
+
   def destroy
-    # 未実装
+    cart_item = CartItem.find(params[:id])
+    cart_item.destroy
+    redirect_to cart_items_path
   end
 
   def destroy_all
-    # 未実装
+    current_user.cart_items.destroy_all
+    redirect_to cart_items_path
   end
 end

--- a/app/views/cart_items/index.html.erb
+++ b/app/views/cart_items/index.html.erb
@@ -1,12 +1,13 @@
 <div class="row">
   <div class="col-xs-4">
     <h2>ショッピングカート</h2>
+    <%= link_to "テスト用/ケーキをカートに追加", cart_items_path, method: :post %>
   </div>
   <div class="col-xs-offset-6 col-xs-2">
     <%= link_to "カートを空にする", destroy_all_cart_items_path, method: :delete  %>
   </div>
 </div>
-
+<% total_price = 0 %><%#= FIX: 仮設置 %>
 <div class="row">
   <table class="table cart_items-table">
     <thead>
@@ -20,14 +21,19 @@
     </thead>
 
     <tbody>
-      <% @cart_items.each do |item| %>
+      <% @cart_items.each do |cart_item| %>
+        <% price = cart_item.item.price * cart_item.how_many %>
         <tr>
-          <td><%= item.name %></td>
-          <td><%= item.price %></td>
-          <td><%= item.haw_many %></td>
-          <td><%= item.price * item.haw_many %>円</td>
-          <td><%= link_to "削除する", cart_item_path(@item.id), method: :delete %></td>
+          <td><%= cart_item.item.name %></td>
+          <td><%= cart_item.item.price %></td>
+
+          <%# FIX: 数量設定機能は未実装です %>
+          <td><%= cart_item.how_many %></td>
+
+          <td><%= price %>円</td>
+          <td><%= link_to "削除する", cart_item_path(cart_item), method: :delete %></td>
         </tr>
+        <% total_price += price %>
       <% end %>
     </tbody>
   </table>
@@ -41,7 +47,7 @@
     <table class="table">
       <tr>
         <th>合計金額</th>
-        <td>300億円</td>
+        <td><%= total_price %>円</td>
       </tr>
     </table>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 
   <body>
     <div class='body'>
-      <%#=render 'layouts/header' %>
+      <%=render 'layouts/header' %>
       <div class='container'>
         <%= yield %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 
   <body>
     <div class='body'>
-      <%=render 'layouts/header' %>
+      <%#=render 'layouts/header' %>
       <div class='container'>
         <%= yield %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,8 +15,8 @@ Rails.application.routes.draw do
 
   resources :shipping_adresses, only: [:index, :create, :edit, :update, :destroy]
 
+  delete 'cart_items/destroy_all' => 'cart_items#destroy_all', as: 'destroy_all_cart_items'
   resources :cart_items, only: [:index, :create, :updeate, :destroy]
-  get 'cart_items/destroy_all' => 'cart_items#destroy_all', as: 'destroy_all_cart_items'
 
   resources :orders, only: [:index, :new, :create, :show]
   post 'orders/confirm' => 'orders#confirm', as: 'order_confirm'

--- a/db/migrate/20200601014348_create_items.rb
+++ b/db/migrate/20200601014348_create_items.rb
@@ -1,6 +1,12 @@
 class CreateItems < ActiveRecord::Migration[5.2]
   def change
     create_table :items do |t|
+      t.references  :genre, foreign_key: true
+      t.string      :name, null: false
+      t.integer     :price, null: false
+      t.string      :image_id # null: false
+      t.text        :explanation # null: false
+      t.boolean     :is_valid, null: false, default: true
 
       t.timestamps
     end

--- a/db/migrate/20200601014501_create_cart_items.rb
+++ b/db/migrate/20200601014501_create_cart_items.rb
@@ -1,7 +1,9 @@
 class CreateCartItems < ActiveRecord::Migration[5.2]
   def change
     create_table :cart_items do |t|
-
+      t.references :item,     null: false, foreign_key: true
+      t.references :user,     null: false, foreign_key: true
+      t.integer    :how_many, null: false, default: 1
       t.timestamps
     end
   end

--- a/db/migrate/20200601170722_add_columns_to_cart_items.rb
+++ b/db/migrate/20200601170722_add_columns_to_cart_items.rb
@@ -1,7 +1,0 @@
-class AddColumnsToCartItems < ActiveRecord::Migration[5.2]
-  def change
-    add_reference :cart_items, :item, foreign_key: true
-    add_reference :cart_items, :user, foreign_key: true
-    add_column :cart_items, :how_many, :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_01_170722) do
+ActiveRecord::Schema.define(version: 2020_06_01_053611) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -25,11 +25,11 @@ ActiveRecord::Schema.define(version: 2020_06_01_170722) do
   end
 
   create_table "cart_items", force: :cascade do |t|
+    t.integer "item_id", null: false
+    t.integer "user_id", null: false
+    t.integer "how_many", default: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "item_id"
-    t.integer "user_id"
-    t.integer "how_many"
     t.index ["item_id"], name: "index_cart_items_on_item_id"
     t.index ["user_id"], name: "index_cart_items_on_user_id"
   end
@@ -40,8 +40,15 @@ ActiveRecord::Schema.define(version: 2020_06_01_170722) do
   end
 
   create_table "items", force: :cascade do |t|
+    t.integer "genre_id"
+    t.string "name", null: false
+    t.integer "price", null: false
+    t.string "image_id"
+    t.text "explanation"
+    t.boolean "is_valid", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["genre_id"], name: "index_items_on_genre_id"
   end
 
   create_table "order_items", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,8 +5,19 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-#追記
+
+# 追記
 Admin.create!(
    email: 'nagano_cake@test.com',
    password: 'testtest',
+)
+
+User.create!(
+   email: 'user@test.com',
+   password: 'testtest',
+)
+
+Item.create!(
+   name: "ケーキ",
+   price: 500,
 )


### PR DESCRIPTION
# カート一覧編集削除機能の追加
主な変更点は以下です。
###  controller
* createアクションの追加
* destroyアクションの追加
* destroy_allアクションの追加

### view
* index を機能が使えるように整理

### DB(マイグレーションファイル)
* cart_itemにカラムを追加
* item にカラムを追加
* seedにUser1人とItem1つ追加

### routes
* destroy_all のルーティングをdestroyの上に移動（入れ替えないとdestroyアクションになってしまう）