### PR TITLE
fix fix orders list syntaxerorr

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,14 @@ class User < ApplicationRecord
     super && (is_valid == '有効')
   end
 
+  def show_validation
+    if is_valid == '無効'
+      '退会済'
+    else
+      '有効'
+    end
+  end
+
   def full_name
     "#{family_name} #{first_name}"
   end

--- a/app/views/admins/users/index.html.erb
+++ b/app/views/admins/users/index.html.erb
@@ -19,13 +19,13 @@
 							<%= user.id %>
 						</td>
 						<td>
-							<%= "#{user.family_name} #{user.first_name}" %>
+							<%= link_to "#{user.family_name} #{user.first_name}", admins_user_path(user) %>
 						</td>
 						<td>
 							<%= user.email %>
 						</td>
 						<td>
-							<%= "#{user.is_valid}ステータス未実装" %>
+							<%= user.show_validation %>
 						</td>
 					</tr>
 				<% end %>


### PR DESCRIPTION
# 管理者側顧客一覧表示機能 SyntaxErorr修正、メソッド名変更
### 確認してほしいこと
* 氏名を顧客詳細画面へのリンクに設定できているのか
* 会員ステータスを無効から退会済に変更できているか
### model
* user.rb にshow_validationメソッドを定義しfalseの場合に退会済と表示できるように記述
### view
* view/admins/users/indexの氏名を顧客詳細画面へのリンクに設定、又、会員ステータスをshow_valitationメソッドで表示