### PR TITLE
fix admins top page

### DIFF
--- a/app/controllers/admins/home_controller.rb
+++ b/app/controllers/admins/home_controller.rb
@@ -1,5 +1,4 @@
 class Admins::HomeController < ApplicationController
   def index
-    @orders = Order.all # １日の注文数ですが、未実装です。一時的に全件取得しています。
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -29,4 +29,11 @@ class Order < ApplicationRecord
     end
     how_many
   end
+
+  def self.order_count
+    from  = Time.current.at_beginning_of_day
+    to    = (from + 1.day).at_end_of_day
+    items = Order.where(created_at: from...to)
+    items.count
+  end
 end

--- a/app/views/admins/home/index.html.erb
+++ b/app/views/admins/home/index.html.erb
@@ -5,8 +5,8 @@
 	<div class="row">
 		<table class="table">
 			<tr>
-				<th>本日の注文件数(未実装のためOrder全件表示しています)</th>
-				<td><%= "#{@orders.count} 件" %></td>
+				<th>本日の注文件数</th>
+				<td><%= "#{Order.order_count} 件" %></td>
 			</tr>
 		</table>
 	</div>


### PR DESCRIPTION
# 管理者側トップページ当日分のみのレコードを取得
### 確認してほしいこと
* 顧客側で注文をし、管理者側トップページの表示件数が変化するか
### model
* 当日に注文されたレコード件数を表示させるメソッドを定義
### controller
* indexアクションに変数は必要ないので削除
### view
* モデルから当日分注文件数を取得するメソッドを呼び出す記述